### PR TITLE
Use MessageEntity to parse command and its args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: rust
 rust:
-  - stable
-  - beta
   - nightly
 matrix:
-  allow_failures:
-    - rust: nightly
   fast_finish: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "telegram-bot-raw 0.6.1 (git+https://github.com/telegram-rs/telegram-bot?rev=a2db63764dc7bb590104c0ea7b38f0b6191c7d0a)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-curl 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -810,6 +811,23 @@ dependencies = [
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-curl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1139,6 +1157,7 @@ dependencies = [
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d00555353b013e170ed8bc4e13f648a317d1fd12157dbcae13f7013f6cf29f5"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
+"checksum tokio-curl 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b6d237aa125c29d772c3c650d073a58dd66782eebf27bd9172304e38f3481da8"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
 "checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,42 +1,115 @@
-extern crate regex;
+#![feature(try_from)]
+use std::convert::TryFrom;
 
-use regex::Regex;
+use std::fmt;
 
-pub struct Transformer {
-    cmd_pattern: Regex,
+fn is_valid(text: &str) -> bool {
+    text.len() >= 3 && text.len() <= 500
 }
 
-impl Transformer {
-    pub fn new() -> Transformer {
-        Transformer {
-            cmd_pattern: Regex::new(r"([A-z_]+)(@[A-z_]+)?(.*)").unwrap(),
-        }
-    }
+pub struct Square {
+    pub raw: String,
+}
 
-    pub fn transform(&self, data: &str) -> Option<String> {
-        if let Some(caps) = self.cmd_pattern.captures(data) {
-            match (caps.get(1), caps.get(3)) {
-                (Some(cmd), Some(text)) => {
-                    let text = text.as_str().trim();
-                    let text_size = text.len();
-                    if text_size < 3 || text_size > 500 {
-                        return None;
-                    }
-                    Some(match cmd.as_str() {
-                        "square" => to_square(text),
-                        "star" => to_star(text),
-                        "sw" => to_sw(text),
-                        "qstar" => to_qstar(text),
-                        _ => return None,
-                    })
-                }
-                _ => None,
-            }
+impl<'a> TryFrom<&'a str> for Square {
+    type Error = ();
+
+    fn try_from(text: &'a str) -> Result<Square, Self::Error> {
+        let trimmed = text.trim();
+        if is_valid(trimmed) {
+            Ok(Square{
+                raw: to_square(trimmed),
+            })
         } else {
-            None
+            Err(())
         }
     }
 }
+
+impl fmt::Display for Square {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+
+pub struct Star {
+    pub raw: String,
+}
+
+impl<'a> TryFrom<&'a str> for Star {
+    type Error = ();
+
+    fn try_from(text: &'a str) -> Result<Star, Self::Error> {
+        let trimmed = text.trim();
+        if is_valid(trimmed) {
+            Ok(Star{
+                raw: to_star(trimmed),
+            })
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl fmt::Display for Star {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+
+pub struct Qstar {
+    pub raw: String,
+}
+
+impl<'a> TryFrom<&'a str> for Qstar {
+    type Error = ();
+
+    fn try_from(text: &'a str) -> Result<Qstar, Self::Error> {
+        let trimmed = text.trim();
+        if is_valid(trimmed) {
+            Ok(Qstar{
+                raw: to_qstar(trimmed),
+            })
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl fmt::Display for Qstar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+
+
+pub struct Sw {
+    pub raw: String,
+}
+
+impl<'a> TryFrom<&'a str> for Sw {
+    type Error = ();
+
+    fn try_from(text: &'a str) -> Result<Sw, Self::Error> {
+        let trimmed = text.trim();
+        if is_valid(trimmed) {
+            Ok(Sw{
+                raw: to_sw(trimmed),
+            })
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl fmt::Display for Sw {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+
+
+
 
 fn collect_chars(s: &str) -> Vec<char> {
     s.chars().flat_map(|c| c.to_uppercase()).collect()
@@ -263,42 +336,47 @@ mod tests {
     }
 
     #[test]
-    fn it_works() {
-        let tf = Transformer::new();
-
-        for i in vec!["/square@bot text", "/square text", "/square@s_oMe_bot text"] {
-            let data = tf.transform(i).unwrap();
-            assert_text_square(&data);
-        }
-
-        for i in vec!["/star@bot text", "/star text", "/star@s_oMe_bot text"] {
-            let data = tf.transform(i).unwrap();
-            assert_text_star(&data);
-        }
-
-        for i in vec!["/qstar@bot text", "/qstar text", "/qstar@s_oMe_bot text"] {
-            let data = tf.transform(i).unwrap();
-            assert_text_qstar(&data);
-        }
-
-        for i in vec!["/sw@bot rurust", "/sw rurust", "/sw@s_oMe_bot rurust"] {
-            let data = tf.transform(i).unwrap();
-            assert_text_sw(&data);
-        }
+    fn transform_square() {
+        let i = "text";
+        let data = to_square(i);
+        assert_text_square(&data);
     }
 
     #[test]
-    fn it_not_works() {
-        let tf = Transformer::new();
-        for i in vec![
-            "",
-            "/square",
-            "/star ",
-            "/qstar x",
-            "/square xx",
-            &format!("/star {}", String::from_utf8(vec![b'X'; 501]).unwrap()),
-        ] {
-            assert_eq!(tf.transform(&i).is_none(), true);
-        }
+    fn transform_star() {
+        let i = "text";
+        let data = to_star(i);
+        assert_text_star(&data);
     }
+
+    #[test]
+    fn transform_qstar() {
+        let i = "text";
+        let data = to_qstar(i);
+        assert_text_qstar(&data);
+    }
+
+    #[test]
+    fn transform_sw() {
+        let i = "rurust";
+        let data = to_sw(i);
+        assert_text_sw(&data);
+    }
+
+    // FIXME: Convert this test to validate `TBot::process_message()`
+
+    // #[test]
+    // fn it_not_works() {
+    //     let tf = Transformer::new();
+    //     for i in vec![
+    //         "",
+    //         "/square",
+    //         "/star ",
+    //         "/qstar x",
+    //         "/square xx",
+    //         &format!("/star {}", String::from_utf8(vec![b'X'; 501]).unwrap()),
+    //     ] {
+    //         assert_eq!(tf.transform(&i).is_none(), true);
+    //     }
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(try_from)]
+
 extern crate dotenv;
 extern crate futures;
 extern crate telegram_bot;
@@ -8,27 +10,48 @@ use dotenv::dotenv;
 use futures::Stream;
 use std::env;
 use telegram_bot::prelude::*;
-use telegram_bot::{Api, MessageKind, ParseMode, UpdateKind};
-use teletext::Transformer;
+use telegram_bot::{Api, ParseMode, UpdateKind};
+use telegram_bot::{MessageKind, MessageEntityKind};
+use teletext::{Square, Star, Qstar, Sw};
 use tokio_core::reactor::Core;
+
+use std::convert::TryInto;
 
 fn main() {
     dotenv().ok();
     let mut core = Core::new().unwrap();
     let token = env::var("TELETEXT_TOKEN").unwrap();
     let api = Api::configure(token).build(core.handle()).unwrap();
-    let trans = Transformer::new();
     let future = api.stream().for_each(|update| {
         if let UpdateKind::Message(message) = update.kind {
-            if let MessageKind::Text { ref data, .. } = message.kind {
-                if let Some(reply) = trans.transform(data) {
-                    api.spawn(
-                        message
-                            .text_reply(format!("```\n{}\n```", reply))
-                            .parse_mode(ParseMode::Markdown),
-                    );
-                }
-            }
+            let mut result = Err(());
+            if let MessageKind::Text { ref data, ref entities } = message.kind {
+                if let Some(first) = entities.first() {
+                    // Check if the first token is MessageEntityKind::BotCommand,
+                    // Offset is probably 0 because telegram trims the leading spaces
+                    if first.kind != MessageEntityKind::BotCommand || first.offset != 0 {
+                        return Ok(())
+                    }
+
+                    let (cmd, text) = data.split_at(first.length as usize);
+
+                    result = match cmd {
+                        "/square" => Ok(format!("{}", text.try_into().unwrap_or(Square{ raw: "goforkurself".into() }))),
+                        "/star" => Ok(format!("{}", text.try_into().unwrap_or(Star{ raw: "goforkurself".into() }))),
+                        "/qstar" => Ok(format!("{}", text.try_into().unwrap_or(Qstar{ raw: "goforkurself".into() }))),
+                        "/sw" => Ok(format!("{}", text.try_into().unwrap_or(Sw{ raw: "goforkurself".into() }))),
+                        _ => Err(())
+                    };
+                };
+            };
+
+            if let Ok(reply) = result {
+                api.spawn(
+                    message
+                        .text_reply(format!("```\n{}\n```", reply))
+                        .parse_mode(ParseMode::Markdown),
+                );
+            };
         }
         Ok(())
     });


### PR DESCRIPTION
## Commit includes the following changes:

* MessageEntity is used to parse bot command and arguments
  (Resolves #10)
